### PR TITLE
Remove semicolons from end of #include directives

### DIFF
--- a/src/ConfigTool.cpp
+++ b/src/ConfigTool.cpp
@@ -3,11 +3,11 @@
 	Author:	Tvde1
 */
 
-#include "ConfigTool.h";
-#include "FS.h";
-#include "ArduinoJson.h";
-#include "ESP8266WebServer.h";
-#include <map>;
+#include "ConfigTool.h"
+#include "FS.h"
+#include "ArduinoJson.h"
+#include "ESP8266WebServer.h"
+#include <map>
 
 void ConfigTool::load() {
 	SPIFFS.begin();

--- a/src/ConfigTool.h
+++ b/src/ConfigTool.h
@@ -3,11 +3,11 @@
 	Author:	Tvde1
 */
 
-#include <Arduino.h>;
-#include <map>;
+#include <Arduino.h>
+#include <map>
 #include "ArduinoJson.h"
-#include "ESP8266WebServer.h";
-#include <string>;
+#include "ESP8266WebServer.h"
+#include <string>
 
 #ifndef _ConfigTool_h
 #define _ConfigTool_h


### PR DESCRIPTION
These cause annoying compiler warnings:
```
warning: extra tokens at end of #include directive
```